### PR TITLE
Drag & Drop corrections

### DIFF
--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -247,7 +247,7 @@
     flex-direction: row;
     flex-wrap: wrap;
     position: absolute;
-    width: 600px;
+    width: 1000px;
 }
 .xblock--drag-and-drop .zone .item-align-center .option {
     box-sizing: border-box;

--- a/drag_and_drop_v2/public/css/drag_and_drop.css
+++ b/drag_and_drop_v2/public/css/drag_and_drop.css
@@ -246,6 +246,8 @@
     text-align: center;
     flex-direction: row;
     flex-wrap: wrap;
+    position: absolute;
+    width: 600px;
 }
 .xblock--drag-and-drop .zone .item-align-center .option {
     box-sizing: border-box;

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1605,7 +1605,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                     if ($zone.is('.item-bank')) {
                         returnItemToBank(item_id);
                     } else {
-
+                        // placeGrabbedItem($zone);
                         var answer_card = evt.target;
 
                         for ( var i = 0; i < 3 && !answer_card.classList.contains('option'); i++) {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1605,7 +1605,6 @@ function DragAndDropBlock(runtime, element, configuration) {
                     if ($zone.is('.item-bank')) {
                         returnItemToBank(item_id);
                     } else {
-                        // placeGrabbedItem($zone);
                         var answer_card = evt.target;
 
                         for ( var i = 0; i < 3 && !answer_card.classList.contains('option'); i++) {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1695,6 +1695,22 @@ function DragAndDropBlock(runtime, element, configuration) {
         $container.on('touchmove', '.dragged-items .options[draggable=true]', function(evt) {
             evt.preventDefault();
         });
+
+        $container.on('mouseover', '.option.fade', function(evt) {
+            var answer_card = evt.target;
+
+            evt.preventDefault();
+
+            for ( var i = 0; i < 3 && !answer_card.classList.contains('option'); i++) {
+                answer_card = answer_card.parentElement;
+                if (answer_card.classList.contains('option')) {
+                    break;
+                }
+            }
+            // set the hovered answer card with a largest z-index
+            answer_card.style.setProperty('z-index', 100, 'important');
+            $(answer_card).siblings().css( 'zIndex', 10 );
+        });
     };
 
     var grabItem = function($item, interaction_type) {

--- a/drag_and_drop_v2/public/js/drag_and_drop.js
+++ b/drag_and_drop_v2/public/js/drag_and_drop.js
@@ -1605,6 +1605,7 @@ function DragAndDropBlock(runtime, element, configuration) {
                     if ($zone.is('.item-bank')) {
                         returnItemToBank(item_id);
                     } else {
+
                         var answer_card = evt.target;
 
                         for ( var i = 0; i < 3 && !answer_card.classList.contains('option'); i++) {
@@ -1819,7 +1820,43 @@ function DragAndDropBlock(runtime, element, configuration) {
             url: runtime.handlerUrl(element, 'show_answer'),
             data: '{}',
         }).done(function(data) {
-            state.items = data.items;
+            // we calculate x/y for each item in zone according the number of cards in that zone
+            var zones_heights = {};
+            var zone_items_count = {};
+            for (const [item_id, item] of Object.entries(data.items)) {
+                var zone_div_id = configuration.url_name + '-' + item.zone;
+                if (zone_div_id in zone_items_count) {
+                    zone_items_count[zone_div_id] += 1;
+                } else {
+                    zone_items_count[zone_div_id] = 1;
+                }
+                if (!(zone_div_id in zones_heights)) {
+                    var zone = document.getElementById(zone_div_id);
+                    zones_heights[zone_div_id] = zone.clientHeight;
+                }
+            };
+
+            state.items = [];
+            var added_items_count = {};
+            for (const [item_id, item] of Object.entries(data.items)) {
+                var zone_div_id = configuration.url_name + '-' + item.zone;
+                var cloned_item = JSON.parse(JSON.stringify(item));
+                var zone_height = zones_heights[zone_div_id];
+                var zone_item_count = zone_items_count[zone_div_id];
+                var added_item_count = 0;
+                if(zone_div_id in added_items_count) {
+                    added_item_count = added_items_count[zone_div_id];
+                } else {
+                    added_items_count[zone_div_id] = 0;
+                }
+
+                cloned_item.item_x = 0;
+                cloned_item.item_y = added_item_count * Math.min(35, zone_height/zone_item_count);
+                state.items.push(cloned_item);
+
+                added_items_count[zone_div_id] += 1;
+            };
+
             state.showing_answer = true;
             delete state.feedback;
         }).always(function() {

--- a/drag_and_drop_v2/zone_template.py
+++ b/drag_and_drop_v2/zone_template.py
@@ -185,8 +185,8 @@ class ZonesDefinition(object):
                     'item_x': _positions[zone]['item_x'],
                     'item_y': _positions[zone]['item_y']
                 }
-                _positions[zone]['item_x'] += 15
-                _positions[zone]['item_y'] += 15
+                _positions[zone]['item_x'] = 0
+                _positions[zone]['item_y'] += 35
 
         return {'items': _state}
 


### PR DESCRIPTION
# Task
 - https://foundever.atlassian.net/browse/TRIB-745

# Previous PR
 - https://github.com/Learningtribes/xblock-drag-and-drop-v2/pull/4/files

# Tested in Devstack
 - Case A: `Depending on where you drop your answer, labels can be display outside the answer frame` . Tested with `New + Old` version of xblock 👇  
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/32366809-d9db-4b13-9c98-0545805f0329)
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/5b516410-d751-45f3-b343-5e6fde5862c3)
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/a250c578-0fda-412f-b7b8-d980c4c23d08)

 - Case B: `And after pressing Show Answer the answers are display on top of each other`  ( We calculate positions of answer cards according the number of cards + zones height )
( Lots of answer cards in a zone 👇  )
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/963d412a-7829-46e7-8c8c-16124aa7cc8b)
( While mouse `Hovering` on one Answer card )
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/dca57bf1-d6aa-4cdb-8126-b12616a3733b)
( Reduced some answer cards from zones 👇 )
![image](https://github.com/Learningtribes/xblock-drag-and-drop-v2/assets/26813045/beecad1d-c9ac-4db0-8af5-332f723d03a3)




